### PR TITLE
added localhost master node support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.0.5'
+version = '0.0.6'
 
 setup(
     name='sinsh',


### PR DESCRIPTION
# MAJOR # 

## Changelog
Added `path_to_master_data` and `path_to_master_res` inputs to `Cluster().distribute()`.
Added `check_status()` pickle file output for external query.
Updated `copy_res()` to only flatten a node subdir at a time.

Changes allow for use of `localhost` as a cluster node.