### PR TITLE
added wildcard support for copying

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 from setuptools import setup, find_packages
 
 
-version = '0.1.0'
+version = '0.1.1'
 
 setup(
     name='sinsh',

--- a/sinsh/sinsh.py
+++ b/sinsh/sinsh.py
@@ -93,7 +93,10 @@ class Node():
 
         cmd_str = cmd_str + list(args)  # Add any args that were passed in.
 
-        subprocess.run(cmd_str)
+        subprocess.run(
+            ' '.join(cmd_str) if any('*' in a for a in cmd_str) else cmd_str,
+            shell=any('*' in a for a in cmd_str)
+        )  # If passing a wildcard character, set Shell=True, run as string argument.
 
     def rm(self, *args):
         '''


### PR DESCRIPTION
# MINOR # 

## Changelog
`cmd()` now calls `subprocess.run()` with `shell=True` if there is a wildcard character being passed in.